### PR TITLE
riscv: dts: megrez-nx: fix sata act led gpio

### DIFF
--- a/arch/riscv/boot/dts/eswin/eic7700-milkv-megrez-nx.dts
+++ b/arch/riscv/boot/dts/eswin/eic7700-milkv-megrez-nx.dts
@@ -935,7 +935,6 @@
 		&pinctrl_gpio22_default
 		&pinctrl_gpio24_default
 		&pinctrl_gpio26_default
-		&pinctrl_gpio27_default
 		&pinctrl_gpio35_default
 		&pinctrl_gpio36_default
 		&pinctrl_gpio37_default


### PR DESCRIPTION
Release gpio27 because it will be used by stat act led.