### PR TITLE
media: i2c: remove reference to non existing dir

### DIFF
--- a/drivers/media/i2c/Makefile
+++ b/drivers/media/i2c/Makefile
@@ -23,7 +23,6 @@ obj-$(CONFIG_VIDEO_BT819) += bt819.o
 obj-$(CONFIG_VIDEO_BT856) += bt856.o
 obj-$(CONFIG_VIDEO_BT866) += bt866.o
 obj-$(CONFIG_VIDEO_CCS) += ccs/
-obj-$(CONFIG_VIDEO_RK628) += rk628/
 obj-$(CONFIG_VIDEO_CCS_PLL) += ccs-pll.o
 obj-$(CONFIG_VIDEO_CS3308) += cs3308.o
 obj-$(CONFIG_VIDEO_CS5345) += cs5345.o


### PR DESCRIPTION
Fixes the following error:
```
$ make clean
scripts/Makefile.clean:12: drivers/media/i2c/rk628/Makefile: No such file or directory
make[6]: *** No rule to make target 'drivers/media/i2c/rk628/Makefile'.  Stop.
make[5]: *** [scripts/Makefile.clean:61: drivers/media/i2c/rk628] Error 2
make[4]: *** [scripts/Makefile.clean:61: drivers/media/i2c] Error 2
make[3]: *** [scripts/Makefile.clean:61: drivers/media] Error 2
make[2]: *** [scripts/Makefile.clean:61: drivers] Error 2
make[1]: *** [/home/debian/src/rockos-kernel/Makefile:1934: _clean_.] Error 2
make: *** [Makefile:234: __sub-make] Error 2
```